### PR TITLE
Make it a valid pip requirements file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-The following Libraries are used
-
-Intall them before running the code
-
-1: requests
-2: BeautifulSoup
+beautifulsoup4==4.8.1
+certifi==2019.9.11
+chardet==3.0.4
+idna==2.8
+requests==2.22.0
+soupsieve==1.9.4
+urllib3==1.25.6


### PR DESCRIPTION
`requirements.txt` file contains the dump of `pip3 freeze`.
All dependencies can be easily installed via `pip3 install -r requirements.txt` command.